### PR TITLE
Hard-code Pecube's version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Prerequisites
 *.d
 
+# bin folder
+bin/
+
 # Compiled Object files
 *.slo
 *.lo

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Prerequisites
 *.d
 
-# bin folder
-bin/
-
 # Compiled Object files
 *.slo
 *.lo

--- a/src/Pecube.f90
+++ b/src/Pecube.f90
@@ -3,6 +3,7 @@
 program Main
 
 use Pecube
+type (version) :: vers
 type (parameters) :: p, p0
 integer :: nd
 real*4, dimension(1024) :: par
@@ -10,17 +11,25 @@ real*4, dimension(2,1024) :: range
 real*4 :: misfit
 character*5 run
 
+character*9 arg
 integer :: numarg
 
 integer k
 character*9 cparam(1024)
+
 
 numarg=command_argument_count()
 if (numarg.eq.0) then
 write (*,*) 'You need to specify a run directory (i.e. RUN00 for example)'
 stop 'End of run'
 else
-call getarg (1,run)
+   call getarg (1,arg)
+   if (arg.eq.'--version') then
+      write (*,*) vers%str
+      stop
+   else
+      run = arg
+   endif
 endif
 
 ! checks that the run directory exists, otherwise exits

--- a/src/module_Pecube.f90
+++ b/src/module_Pecube.f90
@@ -10,9 +10,9 @@ module Pecube
 
   type version
 
-  character*5 :: str = "4.1.0"
+  character*5 :: str = "4.2.0"
   integer :: major = 4
-  integer :: minor = 1
+  integer :: minor = 2
   integer :: patch = 0
 
   end type version

--- a/src/module_Pecube.f90
+++ b/src/module_Pecube.f90
@@ -6,6 +6,19 @@ module Pecube
 
 !--------------------------------------------------------------------------------------------
 
+! "version" type that contains information about Pecube version
+
+  type version
+
+  character*5 :: str = "4.1.0"
+  integer :: major = 4
+  integer :: minor = 1
+  integer :: patch = 0
+
+  end type version
+
+!--------------------------------------------------------------------------------------------
+
 ! "param" type that contains all input parameters
 
   type parameters
@@ -357,7 +370,7 @@ module Pecube
     integer,intent(inout)::nd
     real*4,intent(inout)::range(2,1024),par(1024)
     end subroutine cscanfile
-    
+
   end interface scanfile
 
 !--------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2 

This PR hard-codes Pecube's version info as a new type in `Pecube` module. It also adds an option to the `Pecube` executable so that

```
   $ Pecube --version
```

just prints out the version string to std-in.

The advantage is that version is easily discoverable and can be tracked even when only the Pecube executable is shared/distributed.

TODO:

- [x] check current version number (4.1.0?) -> 4.2.0
- [x] add version information in console output and/or log file -> #5 
- ~~[ ] maybe add version option/log in other executables as well~~ (later)

