### PR TITLE
Fixed a series of small bugs, including MPI bug, tmp directory, top

### DIFF
--- a/docs/Pecube.adoc
+++ b/docs/Pecube.adoc
@@ -450,10 +450,10 @@ Uplift velocity (in km/Myr) imposed across the entire depth range at the bottom 
 `bottom_right` _(default = `1`)_::
 Uplift velocity (in km/Myr) imposed across the entire depth range at the bottom right corner of the **Pecube** domain (maximum longitude and minimum latitude).
 
-`upper_right` _(default = `1`)_::
+`top_right` _(default = `1`)_::
 Uplift velocity (in km/Myr) imposed across the entire depth range at the upper right corner of the **Pecube** domain (maximum longitude and maximum latitude).
 
-`upper_left` _(default = `1`)_::
+`top_left` _(default = `1`)_::
 Uplift velocity (in km/Myr) imposed across the entire depth range at the upper left corner of the **Pecube** domain (minimum longitude and maximum latitude).
 
 `nstep**__i__**` (no default value)::

--- a/src/Pecube324.f90
+++ b/src/Pecube324.f90
@@ -257,9 +257,9 @@ read (55,'(a1024)') line
     read (55,'(a1024)') line
     write (77,'(a," = ",a)') 'bottom_right',trim(line)
     read (55,'(a1024)') line
-    write (77,'(a," = ",a)') 'upper_right',trim(line)
+    write (77,'(a," = ",a)') 'top_right',trim(line)
     read (55,'(a1024)') line
-    write (77,'(a," = ",a)') 'upper_left',trim(line)
+    write (77,'(a," = ",a)') 'top_left',trim(line)
 ! real fault geometry
     else
       do k=1,n

--- a/src/module_Pecube.f90
+++ b/src/module_Pecube.f90
@@ -10,7 +10,7 @@ module Pecube
 
   type version
 
-  character*5 :: str = "4.2.0"
+  character*5 :: str = "4.2.1"
   integer :: major = 4
   integer :: minor = 2
   integer :: patch = 0
@@ -180,10 +180,10 @@ module Pecube
   character*128 :: bottom_right_desc = "Scaling value for uplift function applied at bottom right corner of grid"
 
   double precision :: upper_right = 1.d0
-  character*128 :: upper_right_desc = "Scaling value for uplift function applied at upper right corner of grid"
+  character*128 :: upper_right_desc = "Scaling value for uplift function applied at top right corner of grid"
 
   double precision :: upper_left = 1.d0
-  character*128 :: upper_left_desc = "Scaling value for uplift function applied at upper left corner of grid"
+  character*128 :: upper_left_desc = "Scaling value for uplift function applied at top left corner of grid"
 
   integer, dimension(:), allocatable :: npoint
   character*128 :: npoint_desc = "number of points used to describe each fault geometry"

--- a/src/naMPI.f
+++ b/src/naMPI.f
@@ -198,7 +198,7 @@ c
 c             		                	Generate or read in
 c						starting models 
 c
- 	call NA_initial_sample
+ 	      call NA_initial_sample
      &       (na_models,nd,ranget,range,nsamplei,
      &        istype,monte,calcmovement,scales,misfit,run)
 c
@@ -223,6 +223,9 @@ c
         tmis = 0.
         tnat = 0.
         ns = nsamplei
+         CALL MPI_BCAST
+     &          (na_models(ntot+1), nsamplei,
+     &           MPI_REAL, 0, MPI_COMM_WORLD, ierr)
 
 
 	do 20 it = 1,itmax+1
@@ -363,6 +366,10 @@ c             taxist2 = taxist2 + taxis2
 
 
 	   end if
+
+            CALL MPI_BCAST
+     &          (na_models(ntot+1), nsample,
+     &           MPI_REAL, 0, MPI_COMM_WORLD, ierr)
 
 c
  20	continue

--- a/src/read_in_fault_parameters.f90
+++ b/src/read_in_fault_parameters.f90
@@ -50,8 +50,8 @@ y2=(y2-xlat1)/(xlat2-xlat1)*yl
   allocate (fault(i)%x(4),fault(i)%y(4))
   fault(i)%x(1) = p%bottom_left
   fault(i)%x(2) = p%bottom_right
-  fault(i)%x(3) = p%upper_right
-  fault(i)%x(4) = p%upper_left
+  fault(i)%x(4) = p%upper_right
+  fault(i)%x(3) = p%upper_left
   else
   allocate (fault(i)%x(fault(i)%n),fault(i)%y(fault(i)%n))
     do k=1,fault(i)%n

--- a/src/read_input_file.f90
+++ b/src/read_input_file.f90
@@ -165,9 +165,9 @@ call scanfile (fnme, "bottom_left", p%bottom_left, p%bottom_left_desc, res, voca
 
 call scanfile (fnme, "bottom_right", p%bottom_right, p%bottom_right_desc, res, vocal, nd, range, par)
 
-call scanfile (fnme, "upper_right", p%upper_right, p%upper_right_desc, res, vocal, nd, range, par)
+call scanfile (fnme, "top_right", p%upper_right, p%upper_right_desc, res, vocal, nd, range, par)
 
-call scanfile (fnme, "upper_left", p%upper_left, p%upper_left_desc, res, vocal, nd, range, par)
+call scanfile (fnme, "top_left", p%upper_left, p%upper_left_desc, res, vocal, nd, range, par)
 
 npoint_max = maxval(p%npoint)
 if (npoint_max.lt.0) npoint_max = 4


### PR DESCRIPTION
@jeanbraun I fixed the following bugs:
MPI error when the different procs failed to synchronize during an inversion when some of the data did not fit inside the model boundaries - fixed in read_data_files.f90
MPI improvement to accelerate convergence in certain cases that involved sharing more information among processors during inversion - fixed in naMPI.f
Error in setting the uplift function at the four corners (top left was setting top right and vice versa)
I took the opportunity to use the more consistent BOTTOM/TOP than BOTTOM/UPPER naming which involved a small change in the documentation too - fixed in read_input_file.f90 and read_in_fault_parameters.f90
Now the 'tmp' folder is created at run time if it does not exist - fixed in read_data_file.f90