### PR TITLE
Fixed issue related to combined velocity fields in read_input_files.f90

### DIFF
--- a/src/read_input_file.f90
+++ b/src/read_input_file.f90
@@ -179,11 +179,14 @@ p%s = 0.d0
   do i = 1, p%nfault
   write (ci,'(i10)') i
     if (p%npoint(i).lt.0) then
-      do j = 1, 4
-      write (cj,'(i10)') j
-      call scanfile (fnme, "r"//trim(adjustl(ci))//"_"//trim(adjustl(cj)), p%r(j,i), p%r_desc, res, vocal, nd, range, par)
-      if (res.eq.999) p%r(j,i)=p%r(j-1,i)
-      enddo
+! these lines were commented out to allow for combining two velocity fields
+! one defined by a fault and one defined by a uniform velocity field (vertical only)
+! These lines were a legacy from Pecube v3
+!      do j = 1, 4
+!      write (cj,'(i10)') j
+!      call scanfile (fnme, "r"//trim(adjustl(ci))//"_"//trim(adjustl(cj)), p%r(j,i), p%r_desc, res, vocal, nd, range, par)
+!      if (res.eq.999) p%r(j,i)=p%r(j-1,i)
+!      enddo
     else
       do j = 1, p%npoint(i)
       write (cj,'(i10)') j


### PR DESCRIPTION
Fixed an issue in read_input_file.f90 that arose due to a legacy option in Pecube v3 that had no reason to remain in the new version. In version 3 Pecube used fake (r,s) locations to impose the velocity at the four corners of the mesh in case a uniform (vertical) velocity field is used rather than a fault. In version 4, 4 new parameters were introduced (bottom/top/left/right) to store this information.