### PR TITLE
NA header file needs only be written to by node 0

### DIFF
--- a/EXMP7/NA/na.in
+++ b/EXMP7/NA/na.in
@@ -1,0 +1,13 @@
+#
+#       Neighbourhood Algorithm input options file
+#
+0         : Algorithm type (NA or Uniform MC: 1=MC,0=NA)
+    4         : Maximum number of iterations
+    8        : Sample size for first iteration
+    8         : Sample size for all other iterations
+    4         : Number of cells to re-sample
+n,210728  : Use Quasi random number generator ? (y/n);random seed
+0         : Type of initial sample (0=random;1=read in a NAD file)
+1         : Output information level (0=silent,1=summary info,2=1+models)
+y         : Turn timing mode on ? (y/n)
+n         : Turn debug mode on ? (y/n)

--- a/src/naMPI.f
+++ b/src/naMPI.f
@@ -496,7 +496,7 @@ c						add NA-info to begining
 c						of header file
 c
         fnme = run//'/NA/na.nad'
-	call NA_header
+	if (lroot) call NA_header
      &       (lu_nad,fnme,header,nh_max,nh,nd,
      &        range,scales,nsamplei,nsample,ncells,nh_user)
 


### PR DESCRIPTION
When used on a large cluster, a lack of synchronization among nodes writing to the na.nad file may corrupt it. To solve this, only node 0 (root) is allowed to access/create/write to na.nad.