### PR TITLE
Adjust default initial mean track length

### DIFF
--- a/src/calculate_ages.f90
+++ b/src/calculate_ages.f90
@@ -65,7 +65,7 @@
             if (ztemp(nrec-irec+1).gt.500) ztemp(nrec-irec+1)=500
             ztemp_3(irec)=ztemp(nrec-irec+1) !MOD VKP
         enddo
-        alo = 16.0
+        alo = 16.3
         final_age = 0
         fmean = 0
         oldest_age  = 0


### PR DESCRIPTION
Rich Ketcham suggests that the default initial mean track length should be 16.3 um to work properly and similar to how it works in HeFTy. Old ages, in particular, will be off by 3-5% with the current code.