### PR TITLE
TL data reading bug solved

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -67,6 +67,7 @@ element_surface.o \
 read_input_file.o \
 scanfile.o \
 read_data_files.o \
+read_table.o \
 ExtractDEM.o \
 initialize_random_seed.o \
 calculate_TL.o \
@@ -113,6 +114,7 @@ element_surface.o \
 read_input_file.o \
 scanfile.o \
 read_data_files.o \
+read_table.o \
 ExtractDEM.o \
 initialize_random_seed.o \
 calculate_TL.o\
@@ -127,6 +129,7 @@ move_fault.o \
 read_in_fault_parameters.o \
 read_input_file.o \
 read_data_files.o \
+read_table.o \
 scanfile.o \
 testTopo.o \
 ExtractDEM.o\

--- a/src/Pecube.f90
+++ b/src/Pecube.f90
@@ -257,7 +257,7 @@ end subroutine writemodels
       double precision, dimension(:,:), allocatable :: theating,released,dreleased,agereleased,dagereleased,duration
       double precision, dimension(:,:), allocatable :: time43He,temperature43He
       double precision, dimension(:), allocatable :: releasedp,agereleasedp
-      double precision, dimension(:,:), allocatable :: doser,d0,radius,et,logs,b,logrho,nn
+      double precision, dimension(:), allocatable :: doser,d0,radius,et,logs,b,logrho,nn
       double precision, dimension(:,:), allocatable :: timeTSL,temperatureTSL
       double precision age43Hep,nnf,paramsTSL(8)
 
@@ -539,8 +539,8 @@ if (nd.eq.0) write (*,*) '------------------------------------------------------
           allocate (nheating(nobs),theating(1024,nobs),released(1024,nobs),dreleased(1024,nobs),duration(1024,nobs))
           allocate (agereleased(1024,nobs),dagereleased(1024,nobs))
           allocate (size43He(nobs),age43He(nobs),dage43He(nobs))
-          allocate (doser(1024,nobs),d0(1024,nobs),radius(1024,nobs),et(1024,nobs),logs(1024,nobs),b(1024,nobs))
-          allocate (logrho(1024,nobs),nn(1024,nobs))
+          allocate (doser(nobs),d0(nobs),radius(nobs),et(nobs),logs(nobs),b(nobs))
+          allocate (logrho(nobs),nn(nobs))
             do i=1,nobs1
             read (7,*) xlonobs,xlatobs,ageheobs,dageheobs,ageftobs,dageftobs, & ! By Xav
                        ageheZobs,dageheZobs,ageftZobs,dageftZobs,agearKobs,dagearKobs, &
@@ -594,9 +594,9 @@ if (nd.eq.0) write (*,*) '------------------------------------------------------
                            +we4(i)*zsurf(iconsurf(npe,ieo(i)))+zl+min(0.d0,heightobs/1.e3)
             enddo
             do i=nobs1+nobs2+nobs3+1,nobs1+nobs2+nobs3+nobs4
-            read (7,*) xlonobs,xlatobs,nheating(i), &
-                      (doser(j,i),d0(j,i),radius(j,i),et(j,i), &
-                      logs(j,i),b(j,i),logrho(j,i),nn(j,i),j=1,nheating(i)), &
+            read (7,*) xlonobs,xlatobs, &
+                      doser(i),d0(i),radius(i),et(i), &
+                      logs(i),b(i),logrho(i),nn(i), &
                       heightobs,ieo(i),we1(i),we2(i),we3(i),we4(i)   ! By Xav
             xexhumationo(i)=we1(i)*xsurf(iconsurf(1,ieo(i))) &
                            +we2(i)*xsurf(iconsurf(2,ieo(i))) &
@@ -1421,7 +1421,7 @@ if (nd.eq.0) write (*,*) '------------------------------------------------------
       allocate (hei(nobs),agehe(nobs),ageheZ(nobs),ageft(nobs),ageftZ(nobs), &
                 agearB(nobs),agearK(nobs),agearM(nobs),agearH(nobs),ftdisto(20,nobs), &
                 temphistp(1024,nobs))
-      if (nd.eq.0.and.nobs1.gt.0) write (13,'(128(a,","))') 'LON','LAT','HEIGHTOBS','HEIGHTPRED', &
+      if (nd.eq.0.and.nobs1.gt.0) write (13,'(a,59(",",a))') 'LON','LAT','HEIGHTOBS','HEIGHTPRED', &
                   'AHEOBS','AHEPRED','AFTOBS','AFTPRED','ZHEOBS','ZHEPRED','ZFTOBS','ZFTPRED', &
                   'KAROBS','KARPRED','BAROBS','BARPRED','MAROBS','MARPRED','HAROBS','HARPRED', &
                   'FT01OBS','FT01PRED','FT02OBS','FT02PRED','FT03OBS','FT03PRED','FT04OBS','FT04PRED', &
@@ -1509,7 +1509,7 @@ if (nd.eq.0) write (*,*) '------------------------------------------------------
         aarMpreg(iobs)=agearM(iobs)
         aarHpreg(iobs)=agearH(iobs)
         hpreg(iobs)=hei(iobs)
-        if (nd.eq.0.and.nobs1.gt.0) write (13,'(128(g12.6,","))') xlonobs,xlatobs,heightobs,hei(iobs), &
+        if (nd.eq.0.and.nobs1.gt.0) write (13,'(g12.6,59(",",g12.6))') xlonobs,xlatobs,heightobs,hei(iobs), &
                           ageheobs,agehe(iobs),ageftobs,ageft(iobs),ageheZobs,ageheZ(iobs), &
                           ageftZobs,ageftZ(iobs), &
                           agearKobs,agearK(iobs),agearBobs,agearB(iobs),agearMobs,agearM(iobs),agearHobs,agearH(iobs), &
@@ -1706,14 +1706,14 @@ if (nd.eq.0) write (*,*) '------------------------------------------------------
 
       if (nd.eq.0.and.nobs4.gt.0) then
       open (13,file=run//'/output/CompareTL.csv',status='unknown')
-      if (nd.eq.0.and.nobs4.gt.0) write (13,'(128(a,","))') 'LON','LAT','DURATION','TEMPERATURE','NN','NNPRED'
+      if (nd.eq.0.and.nobs4.gt.0) write (13,'(a,5(",",a))') 'LON','LAT','HEIGHTOBS','HEIGHTPRED','NNOBS','NNPRED'
       endif
 
       nheating=0
         do iobs=nobs1+nobs2+nobs3+1,nobs1+nobs2+nobs3+nobs4
-        read (7,*) xlonobs,xlatobs,nheating(iobs), &
-                  (doser(j,iobs),d0(j,iobs),radius(j,iobs),et(j,iobs), &
-                  logs(j,iobs),b(j,iobs),logrho(j,iobs),nn(j,i),j=1,nheating(iobs)), &
+        read (7,*) xlonobs,xlatobs, &
+                  doser(iobs),d0(iobs),radius(iobs),et(iobs), &
+                  logs(iobs),b(iobs),logrho(iobs),nn(i), &
                   heightobs,ieobs,wobs1,wobs2,wobs3,wobs4   ! By Xav
         hei(iobs)=wobs1*zsurf(iconsurf(1,ieobs)) &
                   +wobs2*zsurf(iconsurf(2,ieobs)) &
@@ -1730,21 +1730,19 @@ if (nd.eq.0) write (*,*) '------------------------------------------------------
       misfit4 = 0.
       nmisfit4 = 0
         do iobs=nobs1+nobs2+nobs3+1,nobs1+nobs2+nobs3+nobs4
-        write (13,'(g15.9,",",g15.9)') lonobs(iobs),latobs(iobs)
-          do i=1,nheating(iobs)
-          paramsTSL(1)=doser(i,iobs)
-          paramsTSL(2)=d0(i,iobs)
-          paramsTSL(3)=radius(i,iobs)
-          paramsTSL(4)=et(i,iobs)
-          paramsTSL(5)=0.
-          paramsTSL(6)=logs(i,iobs)
-          paramsTSL(7)=b(i,iobs)
-          paramsTSL(8)=logrho(i,iobs)
-          nnf = TLModel (timeTSL(1,iobs), temperatureTSL(1,iobs), jrec, paramsTSL)
-          misfit4=misfit4+(nn(i,iobs) - nnf)**2/(nn(i,iobs)*0.1d0)**2
-          nmisfit4=nmisfit4+1
-          if (nd.eq.0.and.nobs4.gt.0) write (13,'(",",4(",",g15.9))') timeTSL(i,iobs),temperatureTSL(i,iobs),nn(i,iobs),nnf
-          enddo
+        paramsTSL(1)=doser(iobs)
+        paramsTSL(2)=d0(iobs)
+        paramsTSL(3)=radius(iobs)
+        paramsTSL(4)=et(iobs)
+        paramsTSL(5)=0.
+        paramsTSL(6)=logs(iobs)
+        paramsTSL(7)=b(iobs)
+        paramsTSL(8)=logrho(iobs)
+        nnf = TLModel (timeTSL(1,iobs), temperatureTSL(1,iobs), jrec, paramsTSL)
+        misfit4=misfit4+(nn(iobs) - nnf)**2/(nn(iobs)*0.1d0)**2
+        nmisfit4=nmisfit4+1
+        if (nd.eq.0.and.nobs4.gt.0) write (13,'(g15.9,5(",",g15.9))') & 
+          lonobs(iobs),latobs(iobs),heightobs,hei(iobs),nn(iobs),nnf
         enddo
 
       deallocate (timeTSL,temperatureTSL)

--- a/src/create_pecube_in.f90
+++ b/src/create_pecube_in.f90
@@ -34,7 +34,7 @@
       double precision thist(1024),temphist(1024),errortemphist(1024)
       double precision theating(1024),released(1024),dreleased(1024),agereleased(1024),dagereleased(1024),duration(1024)
       double precision size43He,age43He,dage43He
-      double precision doser(1024),d0(1024),radius(1024),et(1024),logs(1024),b(1024),logrho(1024),nn(1024)
+      double precision doser,d0,radius,et,logs,b,logrho,nn
 
       character run*5,fnme*300,obsfile*300,line*1024,c5*5,PecubeFnme*10,cproc*4
 
@@ -316,6 +316,7 @@ endif !VKP
       if (nd0.gt.0) nd=nd0
 
       open (7,status='scratch')
+!      open (7,file='JUNK.txt')
 
       ilog=p%debug
       iterative=1
@@ -470,7 +471,8 @@ endif !VKP
       nobs=0
       write (7,*) nobs,0,0,0
       else
-      call read_data_folder (run//'/data/'//obsfile(1:nobsfile), .true., xlon1, xlon2, xlat1, xlat2, iproc, nd)
+      call read_data_folder (run//'/data/'//obsfile(1:nobsfile), .true., xlon1, xlon2, xlat1, xlat2, iproc, nd, &
+                             nobs1, nobs2, nobs3, nobs4)
         if (nx0.lt.0) then
         allocate (neighz(3,nelem))
         call neighbours (iconz,neighz,nelem)
@@ -481,30 +483,6 @@ endif !VKP
       if (iproc.lt.100) cproc(1:2)='00'
       if (iproc.lt.1000) cproc(1:1)='0'
       open (8,file=run//'/data/'//obsfile(1:nobsfile)//cproc//'.txt',status='old')
-      read (8,*) nobs1
-        do i=1,iabs(nobs1)
-        read (8,*)
-        enddo
-      nobs2=0
-      nobs3=0
-      nobs4=0
-      read (8,*,end=1111) nobs2
-        do i=1,iabs(nobs2)
-        read (8,*)
-        enddo
-      nobs3=0
-      read (8,*,end=1111) nobs3
-        do i=1,iabs(nobs3)
-        read (8,*)
-        enddo
-      nobs4=0
-      read (8,*,end=1111) nobs4
-1111  continue
-        do i=1,iabs(nobs4)
-        read (8,*)
-        enddo
-      rewind (8)
-      read (8,*) nobs1
       if (p%save_PTT_paths.ne.0) nobs1 = -nobs1
       write (7,*) nobs1,nobs2,nobs3,nobs4
       if (nobs1.lt.0) nobs1=-nobs1
@@ -552,8 +530,6 @@ endif !VKP
                     ftdist,heightobs,grainsize,ieobs,wobs1,wobs2,wobs3,wobs4
         enddo
 ! cooling curves
-      read (8,*,end=1112) nobs2
-      if (nobs2.lt.0) nobs2=-nobs2
         do i=1,nobs2
         read (8,*) xlonobs,xlatobs,heightobs,nhist, &
                    (thist(j),temphist(j),errortemphist(j),j=1,nhist)
@@ -594,8 +570,6 @@ endif !VKP
                     heightobs,ieobs,wobs1,wobs2,wobs3,wobs4
         enddo
 ! 4-3He data
-      read (8,*,end=1112) nobs3
-      if (nobs3.lt.0) nobs3=-nobs3
         do i=1,nobs3
         read (8,*) xlonobs,xlatobs,heightobs,size43He,age43He,dage43He,nheating, &
                    (theating(j),duration(j),released(j),dreleased(j), &
@@ -641,12 +615,8 @@ endif !VKP
                     heightobs,ieobs,wobs1,wobs2,wobs3,wobs4
         enddo
 ! TSL data
-        read (8,*,end=1112) nobs4
-1112  continue
-        if (nobs4.lt.0) nobs4=-nobs4
         do i=1,nobs4
-        read (8,*) xlonobs,xlatobs,heightobs,nheating,(doser(j),d0(j),radius(j),et(j),logs(j), &
-                   b(j),logrho(j),nn(j),j=1,nheating)
+        read (8,*) xlonobs,xlatobs,heightobs,doser,d0,radius,et,logs,b,logrho,nn
         if (nx0.gt.0) then
         i1=int((xlonobs-xlon)/(dx*nskip))+1 !VKP
         if (i1.eq.nx) i1=nx-1
@@ -682,8 +652,8 @@ endif !VKP
         endif
         dreleased=max(0.01d0,dreleased)
         dagereleased=max(0.1d0,dagereleased)
-        write (7,*) xlonobs,xlatobs,nheating, &
-          (doser(j),d0(j),radius(j),et(j),logs(j),b(j),logrho(j),nn(j),j=1,nheating), &
+        write (7,*) xlonobs,xlatobs, &
+          doser,d0,radius,et,logs,b,logrho,nn, &
           heightobs,ieobs,wobs1,wobs2,wobs3,wobs4
         enddo
 

--- a/src/read_table.f90
+++ b/src/read_table.f90
@@ -1,0 +1,96 @@
+subroutine read_table(fnme, tag0, ntags0, sample_names, sample_values, nsamples, nsample_max)
+
+! this routine reads from a table from a file
+
+! it transfers into an array "sample_values" the values of the fields (in the table) corresponding to the
+! tags given in tag(ntags) in the same order as they are given in the tag array
+
+! sample_names returns the name of the samples
+! nsamples returns the number of samples
+
+! the table in the file should start with a column labeled SAMPLE
+
+! extra field are neglected
+! if a requested field value is missing (or an entire field) it will appear as -9999.
+
+
+character*1024 line
+character*128 fnme, tag0(ntags0), sample_names(nsample_max)
+double precision sample_values(ntags0, nsample_max)
+integer nsamples
+
+integer, dimension(:), allocatable :: ind
+integer ntags
+character*128, dimension(:), allocatable :: tag
+
+type :: record
+character :: name*128
+double precision :: x(10000)
+end type record
+
+type(record) :: rec
+
+ntags = ntags0 + 1
+
+allocate(ind(ntags), tag(ntags))
+tag(1) = 'SAMPLE'
+tag(2:ntags) = tag0
+
+open (777, file=trim(fnme), status='old')
+
+ind=0
+
+    do while (ind(1).eq.0)
+    read (777, '(a)') line
+    itab = 1
+    istart = 1
+    i = index(line(istart:), ',')
+        do k=1,ntags
+        if (adjustl(trim(tag(k))).eq.adjustl(trim(line(istart:istart+i-2)))) ind(k)=itab
+        enddo
+        do while (i.ne.0)
+        itab = itab + 1
+        istart = istart + i
+        i = index(line(istart:), ',')
+            if (i.ne.0) then
+                do k=1,ntags
+                if (adjustl(trim(tag(k))).eq.adjustl(trim(line(istart:istart+i-2)))) ind(k)=itab
+                enddo
+            else
+                do k=1,ntags
+                if (adjustl(trim(tag(k))).eq.adjustl(trim(line(istart:)))) ind(k)=itab
+                enddo
+            endif
+        enddo
+    enddo
+
+    if (ind(1).ne.1) then
+    print*,'ERROR'
+    print*,'The first non-empty column should be the sample name and thus labeled SAMPLE'
+    goto 999
+    endif
+
+nsamples = 0
+    do
+    read (777, '(a)', end=999) line
+        if (adjustl(trim(line)).ne.'') then
+        nsamples = nsamples + 1
+        rec%x = -9999.
+        read (line,*, end=998) rec
+998     sample_names(nsamples) = adjustl(trim(rec%name))
+            do k=1,ntags0
+                if (ind(k+1).ne.0) then
+                sample_values(k,nsamples) = rec%x(ind(k+1)-1)
+                else
+                sample_values(k,nsamples) = -9999.
+                endif
+            enddo
+        endif
+    enddo
+
+999 close (777)
+
+deallocate (ind, tag)
+
+
+end subroutine read_table


### PR DESCRIPTION
Added a subroutine that facilitates the reading of data in TL/OSL format and incorporated it in the read_data_files subroutine. Several changes were also necessary in the create_pecube_in.f90 routine to simplify the combination of different data types. Changes in Pecube.f90 were also necessary to improve/simplify the output (comparison between observed and predicted OSL data).