### PR TITLE
Increased MPI broadcast size in NA_MPI

### DIFF
--- a/src/naMPI.f
+++ b/src/naMPI.f
@@ -224,7 +224,7 @@ c
         tnat = 0.
         ns = nsamplei
          CALL MPI_BCAST
-     &          (na_models(ntot+1), nsamplei,
+     &          (na_models, nd_max*nmod_max,
      &           MPI_REAL, 0, MPI_COMM_WORLD, ierr)
 
 
@@ -368,7 +368,7 @@ c             taxist2 = taxist2 + taxis2
 	   end if
 
             CALL MPI_BCAST
-     &          (na_models(ntot+1), nsample,
+     &          (na_models, nd_max*nmod_max,
      &           MPI_REAL, 0, MPI_COMM_WORLD, ierr)
 
 c


### PR DESCRIPTION
Found a bug in NA_MPI.f where the dimension of an array was not consistent across routines. This seems to have fixed the problem encountered on some clusters when the parallel optimisation/inversion was used (using MPI)