### PR TITLE
initialized par array

### DIFF
--- a/src/Pecube.f90
+++ b/src/Pecube.f90
@@ -49,6 +49,7 @@ call system ('mkdir "'//run//'/LOG"')
 call system ('rm '//run//'/output/*')
 
 nd = 0
+par = 0.
 call read_input_file (run//'/input/Pecube.in', 0, p0, nd, range, par)
 
 if (nd.eq.0) write (*,*) '---------------------------------------------------------------------------------'


### PR DESCRIPTION
This is a fix to address an issue raised (by email) by @robertxa concerning the model parameter array used in the inversion part of the code that needed to be initialised.