### PR TITLE
Bug in create_pecube_in.f90 l472

### DIFF
--- a/src/create_pecube_in.f90
+++ b/src/create_pecube_in.f90
@@ -469,7 +469,7 @@ endif !VKP
 
       if (obsfile(1:nobsfile).eq.'Nil') then
       nobs=0
-      write (7,*) nobs,0,0,0
+      write (7,*) nobs,0,0,0,0,0
       else
       call read_data_folder (run//'/data/'//obsfile(1:nobsfile), .true., xlon1, xlon2, xlat1, xlat2, iproc, nd, &
                              nobs1, nobs2, nobs3, nobs4, nobs5, nobs6)


### PR DESCRIPTION
A small bug noted by Georgina King that some of the examples did not run; I fix this in create_pecube_in.f90 where the number of observations of different types had not been written to the intermediary input file