### PR TITLE
Small bug in read_input_file.f90 (l 68-70)

### DIFF
--- a/src/read_input_file.f90
+++ b/src/read_input_file.f90
@@ -65,9 +65,9 @@ p%output(:) = 1
   j = i
   call scanfile (fnme, "time_topo"//trim(adjustl(ci)), p%time_topo(j), p%time_topo_desc, res, vocal, nd, range, par)
   call scanfile (fnme, "amplification"//trim(adjustl(ci)), p%amplification(j), p%amplification_desc, res, vocal, nd, range, par)
-  if (res.eq.999) p%amplification(j)=p%amplification(i)
+  if (res.eq.999) p%amplification(j)=p%amplification(i+1)
   call scanfile (fnme, "offset"//trim(adjustl(ci)), p%offset(j), p%offset_desc, res, vocal, nd, range, par)
-  if (res.eq.999) p%offset(j)=p%offset(i)
+  if (res.eq.999) p%offset(j)=p%offset(i+1)
   call scanfile (fnme, "output"//trim(adjustl(ci)), p%output(j), p%output_desc, res, vocal, nd, range, par)
   enddo
 


### PR DESCRIPTION
Small bug fix in read_input_file.f90 in response to email by Ruhong Jiao on July 2, 2024. Code failed to use previous time step amplification and offset factors when a star was specified instead of a value.